### PR TITLE
add support for : grouping, multiplication, default elements ( from emmet spec ) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,3 +142,5 @@ For JQuery you should call Emmet by `$.emmet(a, b, c)` and `$.emmet.template(a, 
 `$.emmet.template(a, b, c)` returns a callable which then returns a JQuery object if you not set the *returnOnlyHTML* to *true*.
 
 *If you call `Emmet(a, b, c)` or `Emmet.template(a, b, c)` you will get the usual Emmet returns, not the JQuery ones.*
+
+

--- a/src/emmet.js
+++ b/src/emmet.js
@@ -1,5 +1,5 @@
 (function () {
-    var indexesRe = /(.+?)(\*\d+)?(>|\+|\^|$)/g;
+    var indexesRe = /(.*?)(\*\d+)?(>|\+|\^|$)/g;
     var escapeRe = /("|')([^\1]*?)\1/g;
     var groupingRe = /\(((?:[^)(]+|\((?:[^)(]+|\([^)(]*\))*\))*)\)/g;
     var innerTextRe = /\{([^}]*?)}/g;
@@ -98,27 +98,29 @@
             })
             .replace(/\s+/g, "")
             .replace(indexesRe, function (full, elText, multi, splitter ) {
-                lastElement = (elText =='()')?
-                    emmetParser(groups.shift()): element(elText,current);
+                if( elText ){
+                    lastElement = (elText =='()')?
+                        emmetParser(groups.shift()): element(elText,current);
 
-                if(multi)
-                    lastElement = multiplication(lastElement,  multi.slice(1));
+                    if(multi)
+                        lastElement = multiplication(lastElement,  multi.slice(1));
 
-                operations.unshift({
-                    parents:current,
-                    childes:lastElement,
-                    sibling: root == current
-                });
+                    operations.unshift({
+                        parents: current,
+                        childes: lastElement,
+                        sibling: root == current
+                    });
+                }
 
                 if (splitter === ">") {
                     lastParents.push( current ) ;
                     current = lastElement;
-                }else if (splitter === "^") current = lastParents.pop();
+                }else if (splitter === "^")
+                    current = lastParents.pop() || root;
             });
 
-        while ( op = operations.shift() ){
-            appendTo(op.parents, op.childes, op.sibling)
-        }
+        while ( op = operations.shift() )
+            appendTo(op.parents, op.childes, op.sibling);
 
         return root;
     }

--- a/src/emmet.js
+++ b/src/emmet.js
@@ -1,83 +1,102 @@
 (function () {
+    const NO_DICTIONARY = false, WITH_DICTIONARY = true;
+
     var indexesRe = /(.*?)(\*\d+)?(>|\+|\^|$)/g;
     var escapeRe = /("|')([^\1]*?)\1/g;
     var groupingRe = /\(((?:[^)(]+|\((?:[^)(]+|\([^)(]*\))*\))*)\)/g;
     var innerTextRe = /\{([^}]*?)}/g;
-    var attrsRe = /\(([^\)]*)\)/g;
-    var excludes = "([^\\.#\\(\\{\\*]+)";
+    var attrsRe = /\[([^\]]*)\]/g;
+    var excludes = "([^\\.#\\[\\{\\*]+)";
     var tagRe = new RegExp("^" + excludes);
     var idRe = new RegExp("#" + excludes, "g");
     var classesRe = new RegExp("\\." + excludes, "g");
-    var variable = /,{\w+}/g;
+    var valuesRe = /,(?:([^,]*):)?([^,]*)/g;
+    var variablesRx =/@(?:(\d+)|(\w+)|(#))(?::([\w-]+))?/g;
+    /*state*/
+    var dictionaryActive = NO_DICTIONARY;
 
-    var escaped = [];
+    var groups = [];
+    var values = [];
+    var namedValues = {};
     var innerTexts = [];
-    var current = null;
+    var escaped = [];
+
+    var defElm = {
+        UL:'li', OL:'li', TABLE:'tr',
+        TBODY:'tr', THEAD:'tr', TFOOT:'tr',
+        TR:'td',
+        SELECT:'option', OPTGROUP:'option'
+    };
     function unescape(text) {
         return text.replace(/""/g, function () {
             return "\"" + escaped.shift() + "\"";
         });
     }
 
-    function element(textParam, parent) {
-        var text = textParam || "";
+    function emmet(text, htmlOnly, args, options){
+        var relVariablRe = /@@(?::([\w-]+))?/g;
 
-        var tag = text.match(tagRe);
-        var id = text.match(idRe);
-        var classes = text.match(classesRe);
-        var attrs = text.match(attrsRe);
-        var innerText = text.match(innerTextRe);
-        var defElm = {
-            UL:'li', OL:'li', TABLE:'tr',
-            TBODY:'tr', THEAD:'tr', TFOOT:'tr',
-            TR:'td',
-            SELECT:'option', OPTGROUP:'option'
-        };
-        var el = document.createElement(tag ? tag[0] : defElm[parent && parent.tagName] || "div");
+        if (args) text = emmet.templatedString(text, args);
+        text = text.replace(valuesRe,function (full, key , value) {
+                if(key)
+                    return namedValues[key] = value,'';
+                return values.push(value), '';
+            })
+            .replace(variablesRx,function (full, index, named, total,defaultValue ) {
+                if(index) return values[index] || defaultValue;
+                if(named) return namedValues[named] || defaultValue;
+                if(total) return values.length || defaultValue;
+                return full;
+            })
 
-        if (id) el.id = id.pop().replace(idRe, "$1");
-        if (classes) {
-            el.className = classes.map(function (className) {
-                return className.slice(1);
-            }).join(" ");
-        }
-        if (innerText) {
-            el.innerHTML += innerText.map(function () {
-                return unescape(innerTexts.shift());
-            }).join(" ");
-        }
-        if (attrs) {
-            attrs.map(function (chunkParam) {
-                var chunk = chunkParam.replace(attrsRe, "$1").split(",");
-                chunk.map(function (attrParam) {
-                    var attr = attrParam.split("=");
-                    var key = attr.shift();
-                    var value = JSON.parse(unescape(attr.join("=")));
+        dictionaryActive = WITH_DICTIONARY;
+        var fragment = emmetParser(text);
+        if(text.match(relVariablRe)|| htmlOnly){
+            var helperDiv = document.createElement('div');
+            helperDiv.appendChild(fragment)
+            var innerHTML = helperDiv.innerHTML
+                    .replace(relVariablRe, (full,defaultValue)=>values.shift() || defaultValue)
 
-                    el.setAttribute(key, value);
-                });
-            });
+
+            if(htmlOnly) return innerHTML
+
+            helperDiv.innerHTML = innerHTML;
+            var len = helperDiv.children.length;
+            while(len--){
+                fragment.appendChild( helperDiv.firstChild );
+            }
         }
-        /*warp with fragment*/
-        return multiplication(el,1);
+
+        /*clean after*/
+        escaped = [];
+        innerTexts = [];
+        groups = [];
+        values = [];
+        namedValues = {};
+        return fragment;
+
+
     }
-    function emmet(text, htmlOnly, args){
-        current = null;
-        var fragment = emmetParser(text, args);
-        // var returnValue = fragment.children.length > 1 ? fragment : fragment.children[0];
-        return htmlOnly ? fragment.innerHTML : fragment;
-    }
-    function emmetParser(text, args) {
+    var colletions = []
+
+
+    function emmetParser(text, parent ,withDictionary) {
         var root =  document.createDocumentFragment();
         var lastElement = null;
         var current = root;
         var lastParents = [root];
         var usedText = text || "";
-        var groups = [];
         var operations = [], op ;
+
+        stack();
+
+        if(parent){
+            /*todo: handle parent default*/
+        }
+
         if (text === void 0) throw new Error("There should be a string to parse.");
 
-        if (args) usedText = emmet.templatedString(text, args);
+
 
         usedText
             .replace(groupingRe, function (full, group) {
@@ -92,19 +111,13 @@
                 innerTexts.push(innerText);
                 return "{}";
             })
-            .replace(variable,function (full, innerText) {
-                innerText.push(innerText);
-                return ''
-            })
             .replace(/\s+/g, "")
             .replace(indexesRe, function (full, elText, multi, splitter ) {
                 if( elText ){
-                    lastElement = (elText =='()')?
-                        emmetParser(groups.shift()): element(elText,current);
+                    var number = multi ? multi.slice(1) : 1;
+                    lastElement = multiplication(elText,current, number);
 
-                    if(multi)
-                        lastElement = multiplication(lastElement,  multi.slice(1));
-
+                    /*todo after that prependTo can be appendTo think about ^ operator*/
                     operations.unshift({
                         parents: current,
                         childes: lastElement,
@@ -119,40 +132,117 @@
                     current = lastParents.pop() || root;
             });
 
-        while ( op = operations.shift() )
-            appendTo(op.parents, op.childes, op.sibling);
+        var pOp = operations.shift();
+        while ( op = operations.shift(), pOp ){
+            if( op && (pOp.parents == op.parents))
+                op.childes.appendChild(pOp.childes)
+            else
+                prependTo(pOp.parents, pOp.childes, pOp.sibling);
+            pOp = op ;
+        }
 
+        unstack();
         return root;
     }
+    function stack() {
+        colletions.push({ escaped, innerTexts });
+        escaped     = []
+        innerTexts  = []
+    }
 
-    function appendTo(parents,children, sibling){
+    function unstack(){
+        var colletion = colletions.pop();
+        escaped = colletion.escaped
+        innerTexts = colletion.innerTexts
+    }
 
+    function element(textParam, parent) {
+
+        if(textParam == '()')
+        /*todo: do somthing with the `args` param*/
+            return  emmetParser(groups.shift(), parent)
+
+        var text = textParam || "";
+        var tag = text.match(tagRe);
+        var id = text.match(idRe);
+        var classes = text.match(classesRe);
+        var attrs = text.match(attrsRe);
+        var innerText = text.match(innerTextRe);
+
+        var dictionary = window.Emmet.dictionary, entry;
+        var el = (()=>{
+                if(dictionaryActive == WITH_DICTIONARY && tag && (entry = dictionary[ tag[0] ])){
+            dictionaryActive = NO_DICTIONARY;
+            var fragment  = emmetParser(entry, parent);
+            dictionaryActive = WITH_DICTIONARY
+            return fragment.firstChild;
+        }
+        return document.createElement(
+            tag ? tag[0] : defElm[parent && parent.tagName] || "div" )
+    })()
+
+        if (id) el.id = id.pop().replace(idRe, "$1");
+        if (classes) {
+            el.classList.add.apply(el,classes.map( className => className.slice(1)).join(" "));
+        }
+        if (innerText) {
+            /*todo: try add text to a right place without run over exist content*/
+            el.innerHTML +=
+                innerText.map( ()=> unescape( innerTexts.shift() ) ).join(" ");
+        }
+        if (attrs) {
+            attrs.map(function (chunkParam) {
+                var chunk = chunkParam.replace(attrsRe, "$1").split(",");
+                chunk.map(function (attrParam) {
+                    var attr = attrParam.split("=");
+                    var key = attr.shift();
+                    var value = unescape(attr.join("="));
+
+                    el.setAttribute(key, value);
+                });
+            });
+        }
+        /*warp with fragment*/
+        return el;
+    }
+
+    function prependTo(parents,children, sibling){
+        /*todo: can be handled defult child for multiple parent*/
+        // console.log(parents, children);
         if(sibling || parents.childNodes.length == 0) {
             parents.insertBefore(children, parents.firstChild );
         }else{
-            parents = parents.childNodes;
-            var len = parents.length;
+            var pNodes = parents.childNodes;
+            var len = pNodes.length;
             /*add the clones elements in the end*/
             if(len > 1)  while(--len){
-                var before = parents[len].firstChild;
-                parents[len].insertBefore( children.cloneNode(true), before);
+                insert(pNodes[len], children.cloneNode(true))
             }
             /*add the original elements in the start*/
-            var before = parents[0].firstChild;
-            parents[0].insertBefore( children, before );
+            insert(pNodes[0],children)
+        }
+
+        function insert(p, child){
+            p.insertBefore( child,p.firstChild);
+            if(p.lastChild.nodeType == 3)
+                p.insertBefore(p.lastChild,p.firstChild)
         }
 
     }
 
-    function multiplication(elements, number){
+    function multiplication( text, parents, number){
         var ret = document.createDocumentFragment();
+        var elements =  element(text, parents);
         if(number > 1)
             while(--number)
-                ret.appendChild(elements.cloneNode(true));
+                ret.appendChild( elements.cloneNode(true) );
         /*add the original elements in the end*/
-        ret.appendChild(elements);
+        ret.insertBefore(elements,ret.firstChild);
+
         return ret;
     }
+
+
 
     emmet.templatedString = function (text, args) {
         return args.reduce(function (str, el, i) {
@@ -170,17 +260,18 @@
     };
 
     window.Emmet = emmet;
+    window.Emmet.dictionary = {};
 
     if (window.jQuery) {
         window.jQuery.emmet = function (text, htmlOnly, args) {
             var el = emmet(text, htmlOnly, args);
-            return htmlOnly ? el : window.jQuery(el);
+            return htmlOnly ? el : window.jQuery(el.children);
         };
         window.jQuery.emmet.template = function (text, htmlOnly, args) {
             var template = emmet.template(text, htmlOnly, args);
             return function () {
                 var el = template.apply(null, arguments);
-                return htmlOnly ? el : window.jQuery(el);
+                return htmlOnly ? el : window.jQuery(el.children);
             };
         };
     }

--- a/src/emmet.js
+++ b/src/emmet.js
@@ -17,7 +17,7 @@
         });
     }
 
-    function element(textParam) {
+    function element(textParam, parent) {
         var text = textParam || "";
 
         var tag = text.match(tagRe);
@@ -25,8 +25,18 @@
         var classes = text.match(classesRe);
         var attrs = text.match(attrsRe);
         var innerText = text.match(innerTextRe);
-
-        var el = document.createElement(tag ? tag[0] : "div");
+        var defElm = {
+            UL:'li',
+            OL:'li',
+            TABLE:'tr',
+            TBODY:'tr',
+            THEAD:'tr',
+            TFOOT:'tr',
+            TR:'td',
+            SELECT:'option',
+            OPTGROUP:'option'
+        };
+        var el = document.createElement(tag ? tag[0] : defElm[ parent && parent.tagName] || "div");
 
         if (id) el.id = id.pop().replace(idRe, "$1");
         if (classes) {
@@ -80,8 +90,8 @@
                 return "{}";
             })
             .replace(/\s+/g, "")
-            .replace(indexesRe, function (full, elementText, splitter,multi) {
-                current.appendChild(lastElement = element(elementText));
+            .replace(indexesRe, function (full, elementText, splitter, multi) {
+                current.appendChild(lastElement = element(elementText,current));
                 if (splitter === ">") current = lastElement;
                 else if (splitter === "^") current = current.parentNode;
                 else if (splitter === '*')

--- a/src/emmet.js
+++ b/src/emmet.js
@@ -1,8 +1,8 @@
 (function () {
-    var indexesRe = /(.+?)(>|\+|\^|$)/g;
+    var indexesRe = /(.+?)(>|\+|\^|$|\*)(\d+)?/g;
     var escapeRe = /("|')([^\1]*?)\1/g;
     var innerTextRe = /\{([^}]*?)}/g;
-    var excludes = "([^\\.#\\(\\{]+)";
+    var excludes = "([^\\.#\\(\\{\\*]+)";
     var attrsRe = /\(([^\)]*)\)/g;
     var tagRe = new RegExp("^" + excludes);
     var idRe = new RegExp("#" + excludes, "g");
@@ -80,10 +80,14 @@
                 return "{}";
             })
             .replace(/\s+/g, "")
-            .replace(indexesRe, function (full, elementText, splitter) {
+            .replace(indexesRe, function (full, elementText, splitter,multi) {
                 current.appendChild(lastElement = element(elementText));
                 if (splitter === ">") current = lastElement;
                 else if (splitter === "^") current = current.parentNode;
+                else if (splitter === '*')
+                    while(--multi)
+                        current.appendChild(lastElement.cloneNode(true))
+
             });
 
         returnValue = tree.children.length > 1 ? tree.children : tree.children[0];

--- a/src/lorem.js
+++ b/src/lorem.js
@@ -1,0 +1,190 @@
+function Lorem() {
+    var langs = {
+        en: {
+            common: ['lorem', 'ipsum', 'dolor', 'sit', 'amet', 'consectetur', 'adipisicing', 'elit'],
+            words: ['exercitationem', 'perferendis', 'perspiciatis', 'laborum', 'eveniet',
+                'sunt', 'iure', 'nam', 'nobis', 'eum', 'cum', 'officiis', 'excepturi',
+                'odio', 'consectetur', 'quasi', 'aut', 'quisquam', 'vel', 'eligendi',
+                'itaque', 'non', 'odit', 'tempore', 'quaerat', 'dignissimos',
+                'facilis', 'neque', 'nihil', 'expedita', 'vitae', 'vero', 'ipsum',
+                'nisi', 'animi', 'cumque', 'pariatur', 'velit', 'modi', 'natus',
+                'iusto', 'eaque', 'sequi', 'illo', 'sed', 'ex', 'et', 'voluptatibus',
+                'tempora', 'veritatis', 'ratione', 'assumenda', 'incidunt', 'nostrum',
+                'placeat', 'aliquid', 'fuga', 'provident', 'praesentium', 'rem',
+                'necessitatibus', 'suscipit', 'adipisci', 'quidem', 'possimus',
+                'voluptas', 'debitis', 'sint', 'accusantium', 'unde', 'sapiente',
+                'voluptate', 'qui', 'aspernatur', 'laudantium', 'soluta', 'amet',
+                'quo', 'aliquam', 'saepe', 'culpa', 'libero', 'ipsa', 'dicta',
+                'reiciendis', 'nesciunt', 'doloribus', 'autem', 'impedit', 'minima',
+                'maiores', 'repudiandae', 'ipsam', 'obcaecati', 'ullam', 'enim',
+                'totam', 'delectus', 'ducimus', 'quis', 'voluptates', 'dolores',
+                'molestiae', 'harum', 'dolorem', 'quia', 'voluptatem', 'molestias',
+                'magni', 'distinctio', 'omnis', 'illum', 'dolorum', 'voluptatum', 'ea',
+                'quas', 'quam', 'corporis', 'quae', 'blanditiis', 'atque', 'deserunt',
+                'laboriosam', 'earum', 'consequuntur', 'hic', 'cupiditate',
+                'quibusdam', 'accusamus', 'ut', 'rerum', 'error', 'minus', 'eius',
+                'ab', 'ad', 'nemo', 'fugit', 'officia', 'at', 'in', 'id', 'quos',
+                'reprehenderit', 'numquam', 'iste', 'fugiat', 'sit', 'inventore',
+                'beatae', 'repellendus', 'magnam', 'recusandae', 'quod', 'explicabo',
+                'doloremque', 'aperiam', 'consequatur', 'asperiores', 'commodi',
+                'optio', 'dolor', 'labore', 'temporibus', 'repellat', 'veniam',
+                'architecto', 'est', 'esse', 'mollitia', 'nulla', 'a', 'similique',
+                'eos', 'alias', 'dolore', 'tenetur', 'deleniti', 'porro', 'facere',
+                'maxime', 'corrupti']
+        },
+        sp: {
+            common: ['mujer', 'uno', 'dolor', 'más', 'de', 'poder', 'mismo', 'si'],
+            words: ['ejercicio', 'preferencia', 'perspicacia', 'laboral', 'paño',
+                'suntuoso', 'molde', 'namibia', 'planeador', 'mirar', 'demás', 'oficinista', 'excepción',
+                'odio', 'consecuencia', 'casi', 'auto', 'chicharra', 'velo', 'elixir',
+                'ataque', 'no', 'odio', 'temporal', 'cuórum', 'dignísimo',
+                'facilismo', 'letra', 'nihilista', 'expedición', 'alma', 'alveolar', 'aparte',
+                'león', 'animal', 'como', 'paria', 'belleza', 'modo', 'natividad',
+                'justo', 'ataque', 'séquito', 'pillo', 'sed', 'ex', 'y', 'voluminoso',
+                'temporalidad', 'verdades', 'racional', 'asunción', 'incidente', 'marejada',
+                'placenta', 'amanecer', 'fuga', 'previsor', 'presentación', 'lejos',
+                'necesariamente', 'sospechoso', 'adiposidad', 'quindío', 'pócima',
+                'voluble', 'débito', 'sintió', 'accesorio', 'falda', 'sapiencia',
+                'volutas', 'queso', 'permacultura', 'laudo', 'soluciones', 'entero',
+                'pan', 'litro', 'tonelada', 'culpa', 'libertario', 'mosca', 'dictado',
+                'reincidente', 'nascimiento', 'dolor', 'escolar', 'impedimento', 'mínima',
+                'mayores', 'repugnante', 'dulce', 'obcecado', 'montaña', 'enigma',
+                'total', 'deletéreo', 'décima', 'cábala', 'fotografía', 'dolores',
+                'molesto', 'olvido', 'paciencia', 'resiliencia', 'voluntad', 'molestias',
+                'magnífico', 'distinción', 'ovni', 'marejada', 'cerro', 'torre', 'y',
+                'abogada', 'manantial', 'corporal', 'agua', 'crepúsculo', 'ataque', 'desierto',
+                'laboriosamente', 'angustia', 'afortunado', 'alma', 'encefalograma',
+                'materialidad', 'cosas', 'o', 'renuncia', 'error', 'menos', 'conejo',
+                'abadía', 'analfabeto', 'remo', 'fugacidad', 'oficio', 'en', 'almácigo', 'vos', 'pan',
+                'represión', 'números', 'triste', 'refugiado', 'trote', 'inventor',
+                'corchea', 'repelente', 'magma', 'recusado', 'patrón', 'explícito',
+                'paloma', 'síndrome', 'inmune', 'autoinmune', 'comodidad',
+                'ley', 'vietnamita', 'demonio', 'tasmania', 'repeler', 'apéndice',
+                'arquitecto', 'columna', 'yugo', 'computador', 'mula', 'a', 'propósito',
+                'fantasía', 'alias', 'rayo', 'tenedor', 'deleznable', 'ventana', 'cara',
+                'anemia', 'corrupto']
+        },
+        ru: {
+            common: ['далеко-далеко', 'за', 'словесными', 'горами', 'в стране', 'гласных', 'и согласных', 'живут', 'рыбные', 'тексты'],
+            words: ['вдали', 'от всех', 'они', 'буквенных', 'домах', 'на берегу', 'семантика',
+                'большого', 'языкового', 'океана', 'маленький', 'ручеек', 'даль',
+                'журчит', 'по всей', 'обеспечивает', 'ее','всеми', 'необходимыми',
+                'правилами', 'эта', 'парадигматическая', 'страна', 'которой', 'жаренные',
+                'предложения', 'залетают', 'прямо', 'рот', 'даже', 'всемогущая',
+                'пунктуация', 'не', 'имеет', 'власти', 'над', 'рыбными', 'текстами',
+                'ведущими', 'безорфографичный', 'образ', 'жизни', 'однажды', 'одна',
+                'маленькая', 'строчка','рыбного', 'текста', 'имени', 'lorem', 'ipsum',
+                'решила', 'выйти', 'большой', 'мир', 'грамматики', 'великий', 'оксмокс',
+                'предупреждал', 'о', 'злых', 'запятых', 'диких', 'знаках', 'вопроса',
+                'коварных', 'точках', 'запятой', 'но', 'текст', 'дал', 'сбить',
+                'себя', 'толку', 'он', 'собрал', 'семь', 'своих', 'заглавных', 'букв',
+                'подпоясал', 'инициал', 'за', 'пояс', 'пустился', 'дорогу',
+                'взобравшись', 'первую', 'вершину', 'курсивных', 'гор', 'бросил',
+                'последний', 'взгляд', 'назад', 'силуэт', 'своего', 'родного', 'города',
+                'буквоград', 'заголовок', 'деревни', 'алфавит', 'подзаголовок', 'своего',
+                'переулка', 'грустный', 'реторический', 'вопрос', 'скатился', 'его',
+                'щеке', 'продолжил', 'свой', 'путь', 'дороге', 'встретил', 'рукопись',
+                'она', 'предупредила',  'моей', 'все', 'переписывается', 'несколько',
+                'раз', 'единственное', 'что', 'меня', 'осталось', 'это', 'приставка',
+                'возвращайся', 'ты', 'лучше', 'свою', 'безопасную', 'страну', 'послушавшись',
+                'рукописи', 'наш', 'продолжил', 'свой', 'путь', 'вскоре', 'ему',
+                'повстречался', 'коварный', 'составитель', 'рекламных', 'текстов',
+                'напоивший', 'языком', 'речью', 'заманивший', 'свое', 'агенство',
+                'которое', 'использовало', 'снова', 'снова', 'своих', 'проектах',
+                'если', 'переписали', 'то', 'живет', 'там', 'до', 'сих', 'пор']
+        }
+    };
+
+    const defaultLang = 'en';
+    const ommitCommonPart = 'false';
+    const min = Math.min.bind(Math);
+
+    function rand(from, to) {
+        return ~~(Math.random()*(to-from)) + from;
+    }
+    
+    function sample(array, count) {
+        array = Array.from(array);
+        var result = [];
+        while (count--){
+            let i = rand(0,array.length-1);
+            result.push(array[i]);
+            array.splice(i,1);
+        }
+        return result;
+    }
+
+    function isBtween(number, from, to ) {
+        return number >= from && number < to;
+    }
+
+    function insertCommas(words) {
+        var len = words.length;
+        var totalCommas =
+                isBtween(0,2)? 0 :
+                    isBtween(len, 3, 6)?  rand(0,1):
+                        isBtween(len, 6, 12)? rand(0,2):
+                            rand(1,4);
+
+        let pos = 0;
+        while (totalCommas--){
+            pos = rand(pos+2,words-2);
+            words.splice(pos,0,',');
+        }
+    }
+
+    function charChoice(str){
+        return str.charAt(rand(0, str.length - 1));
+    }
+
+    function sentence( words, end ) {
+        if (words.length == 0) return  (end || charChoice('?!...'));
+        words[0] = words[0] = words[0].charAt(0).toUpperCase() + words[0].substring(1);
+        return words.join(' ') + (end || charChoice('?!...')); // more dots than question marks
+    }
+    
+    function paragraph(lang, wordCount, startWithCommon) {
+        var data = langs[lang];
+        if( !data ) return '';
+
+        var words = [];
+        var results = [];
+
+        if(startWithCommon && data.common){
+            words = data.common.slice(0,wordCount);
+            if(words.length > 5) words.splice(4,0,',');
+            wordCount -= words.length;
+            results.push( sentence(words, '.') )
+        }
+
+        while( wordCount > 0){
+            words = sample(data.words, min( rand(2,30), wordCount ));
+            wordCount -= words.length;
+            insertCommas(words);
+            results.push( sentence(words) )
+        }
+
+        return results.join(' ');
+        
+
+    }
+    
+    return {
+        addLang: function(lang, data) {
+            if (typeof data === 'string') {
+                data = {
+                    words: data.split(' ').filter(function(item) {
+                        return !!item;
+                    })
+                };
+            } else if (Array.isArray(data)) {
+                data = {words: data};
+            }
+
+            langs[lang] = data;
+        },
+        paragraph:paragraph
+    }
+
+
+}


### PR DESCRIPTION
add support for default elements 
   `li` for `ul`and `ol`
    `tr`for `table`, `tbody`, `thead`and `tfoot`
    `td`for `tr`
    `option`for `select`and `optgroup`
like : `ul>.item*3`  ==>  ul>li.item*3

add support for grouping ( 2 level nest only ) 
like:
    `aa>bb+(cc>dd)+ee`

add support for multiplication 
    `aa>bb*3`

add support for grouping and multiplication together
like:  
    `(a*2+b)*4`
    `ul>{test1}*4`
    `ul>{test1}*4+(ul>{test2})`

start adding `loren` generator
